### PR TITLE
Use Services global variable if possible

### DIFF
--- a/src/api/edsCalendar.js
+++ b/src/api/edsCalendar.js
@@ -20,7 +20,6 @@
 "use strict";
 
 const { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
 
 const { ExtensionAPI } = ExtensionCommon;

--- a/src/legacy/modules/calEdsProvider.jsm
+++ b/src/legacy/modules/calEdsProvider.jsm
@@ -23,7 +23,9 @@
 const { moduleRegistry } = ChromeUtils.import("resource://edscalendar/legacy/modules/utils/moduleRegistry.jsm");
 moduleRegistry.registerModule(__URI__);
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const { AddonManager } = ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
 const { ctypes } = ChromeUtils.import("resource://gre/modules/ctypes.jsm");

--- a/src/legacy/modules/edsCalendarClient.jsm
+++ b/src/legacy/modules/edsCalendarClient.jsm
@@ -25,7 +25,9 @@ moduleRegistry.registerModule(__URI__);
 
 const { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 const { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 const { AddonManager } = ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
 
 const { addLogger } = ChromeUtils.import("resource://edscalendar/legacy/modules/utils/logger.jsm");

--- a/src/legacy/modules/utils/asyncHelper.jsm
+++ b/src/legacy/modules/utils/asyncHelper.jsm
@@ -22,7 +22,9 @@
 const { moduleRegistry } = ChromeUtils.import("resource://edscalendar/legacy/modules/utils/moduleRegistry.jsm");
 moduleRegistry.registerModule(__URI__);
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 const { edsPreferences } = ChromeUtils.import("resource://edscalendar/legacy/modules/utils/edsPreferences.jsm");
 const { addLogger } = ChromeUtils.import("resource://edscalendar/legacy/modules/utils/logger.jsm");

--- a/src/legacy/modules/utils/libLoader.jsm
+++ b/src/legacy/modules/utils/libLoader.jsm
@@ -20,7 +20,9 @@
 const { moduleRegistry } = ChromeUtils.import("resource://edscalendar/legacy/modules/utils/moduleRegistry.jsm");
 moduleRegistry.registerModule(__URI__);
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const { AddonManager } = ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
 const { ctypes } = ChromeUtils.import("resource://gre/modules/ctypes.jsm");

--- a/src/legacy/modules/utils/logger.jsm
+++ b/src/legacy/modules/utils/logger.jsm
@@ -22,7 +22,9 @@ moduleRegistry.registerModule(__URI__);
 
 const { classes: Cc, interfaces: Ci, results: Cr } = Components;
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const { AddonManager } = ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
 

--- a/tests/mozmill/test-calEdsProvider.js
+++ b/tests/mozmill/test-calEdsProvider.js
@@ -18,7 +18,9 @@
  * ***** END LICENSE BLOCK ***** */
 
 Components.utils.import("resource://modules/calendar/calUtils.jsm");
-Components.utils.import("resource://gre/modules/Services.jsm");
+if (!globalThis.Services) {
+  Components.utils.import("resource://gre/modules/Services.jsm");
+}
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 Components.utils.import("resource://mozmill/modules/assertions.js");
 


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and those code doesn't have to import Services.jsm if the strict_min_version is 102.

And also it's available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm for recent versions.